### PR TITLE
Add between and surroundedBy combinators to Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.6.4
+- **New Feature**
+  - add `between` and `surroundedBy` to Parser (@IMax153)
+
 # 0.6.3
 
 - **Bug Fix**

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -19,6 +19,7 @@ Added in v0.6.0
 - [ap](#ap)
 - [apFirst](#apfirst)
 - [apSecond](#apsecond)
+- [between](#between)
 - [chain](#chain)
 - [chainFirst](#chainfirst)
 - [cut](#cut)
@@ -42,6 +43,7 @@ Added in v0.6.0
 - [sepByCut](#sepbycut)
 - [seq](#seq)
 - [succeed](#succeed)
+- [surroundedBy](#surroundedby)
 - [withStart](#withstart)
 
 ---
@@ -117,6 +119,18 @@ Added in v0.6.0
 ```
 
 Added in v0.6.0
+
+# between
+
+Matches the provided parser `p` that occurs between the provided `left` and `right` parsers.
+
+**Signature**
+
+```ts
+export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> { ... }
+```
+
+Added in v0.6.4
 
 # chain
 
@@ -423,6 +437,18 @@ export function succeed<I, A>(a: A): Parser<I, A> { ... }
 ```
 
 Added in v0.6.0
+
+# surroundedBy
+
+Matches the provided parser `p` that is surrounded by the `bound` parser. Shortcut for `between(bound, bound)`.
+
+**Signature**
+
+```ts
+export function surroundedBy<I, A>(bound: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> { ... }
+```
+
+Added in v0.6.4
 
 # withStart
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -283,6 +283,29 @@ export function sepByCut<I, A, B>(sep: Parser<I, A>, p: Parser<I, B>): Parser<I,
 }
 
 /**
+ * Matches the provided parser `p` that occurs between the provided `left` and `right` parsers.
+ *
+ * @since 0.6.4
+ */
+export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> {
+  return p =>
+    pipe(
+      left,
+      chain(() => p),
+      chainFirst(() => right)
+    )
+}
+
+/**
+ * Matches the provided parser `p` that is surrounded by the `bound` parser. Shortcut for `between(bound, bound)`.
+ *
+ * @since 0.6.4
+ */
+export function surroundedBy<I, A>(bound: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> {
+  return between(bound, bound)
+}
+
+/**
  * @since 0.6.0
  */
 export function getMonoid<I, A>(M: Monoid<A>): Monoid<Parser<I, A>> {

--- a/src/string.ts
+++ b/src/string.ts
@@ -154,13 +154,4 @@ export const float: P.Parser<C.Char, number> = P.expected(
  *
  * @since 0.6.0
  */
-export const doubleQuotedString = pipe(
-  C.char('"'),
-  P.chain(() => many(P.either(string('\\"'), () => C.notChar('"')))),
-  P.chain(s =>
-    pipe(
-      C.char('"'),
-      P.chain(() => P.succeed(s))
-    )
-  )
-)
+export const doubleQuotedString = P.surroundedBy(C.char('"'))(many(P.either(string('\\"'), () => C.notChar('"'))))

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -56,4 +56,18 @@ describe('Parser', () => {
     assert.deepStrictEqual(run(parser, 'a,b'), error(stream(['a', ',', 'b'], 2), ['"a"'], true))
     assert.deepStrictEqual(run(parser, 'a,a'), success(['a', 'a'], stream(['a', ',', 'a'], 3), stream(['a', ',', 'a'])))
   })
+
+  it('between', () => {
+    const betweenParens = P.between(C.char('('), C.char(')'))
+    const parser = betweenParens(C.char('a'))
+    assert.deepStrictEqual(run(parser, '(a'), error(stream(['(', 'a'], 2), ['")"']))
+    assert.deepStrictEqual(run(parser, '(a)'), success('a', stream(['(', 'a', ')'], 3), stream(['(', 'a', ')'])))
+  })
+
+  it('surroundedBy', () => {
+    const surroundedByPipes = P.surroundedBy(C.char('|'))
+    const parser = surroundedByPipes(C.char('a'))
+    assert.deepStrictEqual(run(parser, '|a'), error(stream(['|', 'a'], 2), ['"|"']))
+    assert.deepStrictEqual(run(parser, '|a|'), success('a', stream(['|', 'a', '|'], 3), stream(['|', 'a', '|'])))
+  })
 })


### PR DESCRIPTION
Closes https://github.com/gcanti/parser-ts/issues/21. I did not bump the version to `0.6.4` in the PR since I figured this would be done on release.

If there is interest I could also refactor `doubleQuotedString` to use `surroundedBy`.

```typescript
export const doubleQuotedString = P.surroundedBy(C.char('"'))(
  many(P.either(string('\\"'), () => C.notChar('"')))
)
```