### PR TITLE
Make `between` and `surroundedBy` polymorphic in parser type

### DIFF
--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -124,10 +124,12 @@ Added in v0.6.0
 
 Matches the provided parser `p` that occurs between the provided `left` and `right` parsers.
 
+`p` is polymorphic in its return type, because in general bounds and actual parser could return different types.
+
 **Signature**
 
 ```ts
-export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> { ... }
+export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): <B>(p: Parser<I, B>) => Parser<I, B> { ... }
 ```
 
 Added in v0.6.4
@@ -445,7 +447,7 @@ Matches the provided parser `p` that is surrounded by the `bound` parser. Shortc
 **Signature**
 
 ```ts
-export function surroundedBy<I, A>(bound: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> { ... }
+export function surroundedBy<I, A>(bound: Parser<I, A>): <B>(p: Parser<I, B>) => Parser<I, B> { ... }
 ```
 
 Added in v0.6.4

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -285,9 +285,11 @@ export function sepByCut<I, A, B>(sep: Parser<I, A>, p: Parser<I, B>): Parser<I,
 /**
  * Matches the provided parser `p` that occurs between the provided `left` and `right` parsers.
  *
+ * `p` is polymorphic in its return type, because in general bounds and actual parser could return different types.
+ *
  * @since 0.6.4
  */
-export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> {
+export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): <B>(p: Parser<I, B>) => Parser<I, B> {
   return p =>
     pipe(
       left,
@@ -301,7 +303,7 @@ export function between<I, A>(left: Parser<I, A>, right: Parser<I, A>): (p: Pars
  *
  * @since 0.6.4
  */
-export function surroundedBy<I, A>(bound: Parser<I, A>): (p: Parser<I, A>) => Parser<I, A> {
+export function surroundedBy<I, A>(bound: Parser<I, A>): <B>(p: Parser<I, B>) => Parser<I, B> {
   return between(bound, bound)
 }
 

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -57,17 +57,35 @@ describe('Parser', () => {
     assert.deepStrictEqual(run(parser, 'a,a'), success(['a', 'a'], stream(['a', ',', 'a'], 3), stream(['a', ',', 'a'])))
   })
 
-  it('between', () => {
-    const betweenParens = P.between(C.char('('), C.char(')'))
-    const parser = betweenParens(C.char('a'))
-    assert.deepStrictEqual(run(parser, '(a'), error(stream(['(', 'a'], 2), ['")"']))
-    assert.deepStrictEqual(run(parser, '(a)'), success('a', stream(['(', 'a', ')'], 3), stream(['(', 'a', ')'])))
+  describe('between', () => {
+    it('monomorphic', () => {
+      const betweenParens = P.between(C.char('('), C.char(')'))
+      const parser = betweenParens(C.char('a'))
+      assert.deepStrictEqual(run(parser, '(a'), error(stream(['(', 'a'], 2), ['")"']))
+      assert.deepStrictEqual(run(parser, '(a)'), success('a', stream(['(', 'a', ')'], 3), stream(['(', 'a', ')'])))
+    })
+
+    it('polymorphic', () => {
+      const betweenParens = P.between(C.char('('), C.char(')'))
+      const parser = betweenParens(S.int)
+      assert.deepStrictEqual(run(parser, '(1'), error(stream(['(', '1'], 2), ['")"']))
+      assert.deepStrictEqual(run(parser, '(1)'), success(1, stream(['(', '1', ')'], 3), stream(['(', '1', ')'])))
+    })
   })
 
-  it('surroundedBy', () => {
-    const surroundedByPipes = P.surroundedBy(C.char('|'))
-    const parser = surroundedByPipes(C.char('a'))
-    assert.deepStrictEqual(run(parser, '|a'), error(stream(['|', 'a'], 2), ['"|"']))
-    assert.deepStrictEqual(run(parser, '|a|'), success('a', stream(['|', 'a', '|'], 3), stream(['|', 'a', '|'])))
+  describe('surroundedBy', () => {
+    it('monomorphic', () => {
+      const surroundedByPipes = P.surroundedBy(C.char('|'))
+      const parser = surroundedByPipes(C.char('a'))
+      assert.deepStrictEqual(run(parser, '|a'), error(stream(['|', 'a'], 2), ['"|"']))
+      assert.deepStrictEqual(run(parser, '|a|'), success('a', stream(['|', 'a', '|'], 3), stream(['|', 'a', '|'])))
+    })
+
+    it('polymorphic', () => {
+      const surroundedByPipes = P.surroundedBy(C.char('|'))
+      const parser = surroundedByPipes(S.int)
+      assert.deepStrictEqual(run(parser, '|1'), error(stream(['|', '1'], 2), ['"|"']))
+      assert.deepStrictEqual(run(parser, '|1|'), success(1, stream(['|', '1', '|'], 3), stream(['|', '1', '|'])))
+    })
   })
 })


### PR DESCRIPTION
Motivation for this change is described here: https://github.com/gcanti/parser-ts/issues/21#issuecomment-647996821