### PR TITLE
Add example for parsing a command line statement into an AST

### DIFF
--- a/examples/command.ts
+++ b/examples/command.ts
@@ -199,7 +199,7 @@ const cmd = 'foo'
 const source = 'foo ./bar -b --baz=qux'
 
 // tslint:disable-next-line: no-console
-parseCommand(cmd, c => console.error(`command not found: ${c}`))(source)
+console.log(JSON.stringify(parseCommand(cmd, c => console.error(`command not found: ${c}`))(source), null, 2))
 /*
 {
   _tag: 'Right',

--- a/examples/command.ts
+++ b/examples/command.ts
@@ -1,0 +1,210 @@
+/**
+ * In this example, we utilize the combinators from `parser-ts` to demonstrate one possible implementation
+ * of parsing command line statements into a structured abstract syntax tree (AST). Our parser will be
+ * capable of handling a command, named arguments, positional arguments, and flags.
+ *
+ * An example statement might look something like
+ *
+ * ```
+ * foo ./bar -b --baz=qux
+ * ```
+ *
+ * which will then be parsed into an AST with the following structure
+ *
+ * ```
+ * {
+ *   command: 'foo',
+ *   source: 'foo ./bar -b --baz=qux',
+ *   arguments: {
+ *     flags: {
+ *       b: true
+ *     }
+ *     named: {
+ *       baz: "qux",
+ *     },
+ *     positional: {
+ *       0: "./bar",
+ *     },
+ *   }
+ * }
+ * ```
+ *
+ * Parsing our statement into an AST allows us enforce that a statement conforms to some expected structure.
+ * For example, one could generalize the parser exemplified below to accept any command. Then, the
+ * structure of the parsed AST for specific commands can be enforced using instances of `io-ts` `Schema`s.
+ */
+import { array, filter } from 'fp-ts/lib/Array'
+import { bimap, Either } from 'fp-ts/lib/Either'
+import { fromFoldableMap, isEmpty } from 'fp-ts/lib/Record'
+import { getLastSemigroup } from 'fp-ts/lib/Semigroup'
+import { fold } from 'fp-ts/lib/boolean'
+import { identity, tuple, Refinement } from 'fp-ts/lib/function'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { Do } from 'fp-ts-contrib/lib/Do'
+import * as C from '../src/char'
+import * as S from '../src/string'
+import * as P from '../src/Parser'
+import { run } from '../src/code-frame'
+
+// -------------------------------------------------------------------------------------
+// models
+// -------------------------------------------------------------------------------------
+
+export type Statement = Command | Argument
+
+export interface Command {
+  _tag: 'Command'
+  value: string
+}
+
+export type Argument = Flag | Named | Positional
+
+export interface Flag {
+  _tag: 'Flag'
+  value: string
+}
+
+export interface Named {
+  _tag: 'Named'
+  name: string
+  value: string
+}
+
+export interface Positional {
+  _tag: 'Positional'
+  value: string
+}
+
+export interface Ast {
+  command: string
+  source: string
+  args: {
+    flags: Record<string, true> | null
+    named: Record<string, string> | null
+    positional: Record<number, string> | null
+  }
+}
+
+// -------------------------------------------------------------------------------------
+// guards
+// -------------------------------------------------------------------------------------
+
+const isFlag: Refinement<Argument, Flag> = (a): a is Flag => a._tag === 'Flag'
+
+const isNamed: Refinement<Argument, Named> = (a): a is Named => a._tag === 'Named'
+
+const isPositional: Refinement<Argument, Positional> = (a): a is Positional => a._tag === 'Positional'
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
+
+export const Command = (value: string): Command => ({ _tag: 'Command', value })
+
+export const Flag = (value: string): Flag => ({ _tag: 'Flag', value })
+
+export const Named = (name: string, value: string): Named => ({ _tag: 'Named', name, value })
+
+export const Positional = (value: string): Positional => ({ _tag: 'Positional', value })
+
+// -------------------------------------------------------------------------------------
+// parsers
+// -------------------------------------------------------------------------------------
+
+const whitespaceSurrounded = P.surroundedBy(S.spaces)
+
+const dash = C.char('-')
+
+const doubleDash = S.string('--')
+
+const equals = C.char('=')
+
+const identifier = C.many1(C.alphanum)
+
+const flag: P.Parser<string, Flag> = pipe(
+  dash,
+  P.chain(() => identifier),
+  P.map(Flag)
+)
+
+const named: P.Parser<string, Named> = pipe(
+  doubleDash,
+  P.chain(() => P.sepBy1(equals, identifier)),
+  P.map(([name, value]) => Named(name, value))
+)
+
+const positional: P.Parser<string, Positional> = pipe(C.many1(C.notSpace), P.map(Positional))
+
+const argument = P.either<string, Argument>(flag, () => P.either<string, Argument>(named, () => positional))
+
+const statement = (cmd: string) =>
+  Do(P.parser)
+    .bind('command', whitespaceSurrounded(S.string(cmd)))
+    .bind('args', P.many(whitespaceSurrounded(argument)))
+    .done()
+
+const namedToRecord = (as: Array<Named>): Record<string, string> =>
+  fromFoldableMap(getLastSemigroup<string>(), array)(as, a => [a.name, a.value])
+
+const positionalToRecord = (as: Array<Positional>): Record<number, string> => {
+  const withIndex = array.mapWithIndex(as, (i, a) => tuple(String(i), a.value))
+  return fromFoldableMap(getLastSemigroup<string>(), array)(withIndex, identity)
+}
+
+const flagToRecord = (as: Array<Flag>): Record<string, true> =>
+  fromFoldableMap(getLastSemigroup<true>(), array)(as, a => [a.value, true])
+
+const nullIfEmpty = <A extends Record<any, unknown>>(a: A): A | null =>
+  pipe(
+    isEmpty(a),
+    fold(
+      () => a,
+      () => null
+    )
+  )
+
+const ast = (command: string, source: string): P.Parser<string, Ast> => {
+  return pipe(
+    statement(command),
+    P.map(({ command, args }) => ({
+      command,
+      source,
+      args: {
+        flags: pipe(args, filter(isFlag), flagToRecord, nullIfEmpty),
+        named: pipe(args, filter(isNamed), namedToRecord, nullIfEmpty),
+        positional: pipe(args, filter(isPositional), positionalToRecord, nullIfEmpty)
+      }
+    }))
+  )
+}
+
+const parseCommand = <E>(cmd: string, onLeft: (cmd: string) => E) => (source: string): Either<E, Ast> =>
+  pipe(
+    run(ast(cmd, source), source),
+    bimap(() => onLeft(cmd), identity)
+  )
+
+const cmd = 'foo'
+const source = 'foo ./bar -b --baz=qux'
+
+parseCommand(cmd, c => console.error(`command not found: ${c}`))(source)
+/*
+{
+  _tag: 'Right',
+  right: {
+    command: 'foo',
+    source: 'foo ./bar -b --baz=qux',
+    args: {
+      flags: {
+        b: true
+      },
+      named: {
+        baz: 'qux'
+      },
+      positional: {
+        '0': './bar'
+      }
+    }
+  }
+}
+*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parser-ts",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1765,7 +1765,7 @@
       "integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
       "dev": true,
       "requires": {
-        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#e0561530379dfa01324a89936b75d90b20df9bd2",
+        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
         "fs-extra": "^6.0.1",
         "strip-json-comments": "^2.0.1",
         "tslint": "^5.12.0",
@@ -2222,6 +2222,12 @@
       "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ==",
       "dev": true
     },
+    "fp-ts-contrib": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/fp-ts-contrib/-/fp-ts-contrib-0.1.17.tgz",
+      "integrity": "sha512-UBQ7AdGp0GktLkIn3e6npVIfLm1ZM+racizgVqL88j6HBLBoBjRtVjIxRIS6YbNypuP94ngaZpy2SEib9lnZ9A==",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2268,7 +2274,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2289,12 +2296,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2309,17 +2318,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2436,7 +2448,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2448,6 +2461,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2462,6 +2476,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2469,12 +2484,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2493,6 +2510,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2573,7 +2591,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2585,6 +2604,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2670,7 +2690,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2706,6 +2727,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2725,6 +2747,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2768,12 +2791,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "lint": "tslint -p .",
     "mocha": "mocha -r ts-node/register test/*.ts",
-    "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",
-    "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test}/**/*.ts\"",
+    "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test,examples}/**/*.ts\"",
+    "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test,examples}/**/*.ts\"",
     "test": "npm run lint && npm run prettier && npm run jest && npm run docs",
     "clean": "rm -rf ./lib ./es6",
     "prebuild": "npm run clean",
@@ -43,6 +43,7 @@
     "docs-ts": "^0.3.4",
     "dtslint": "^0.4.2",
     "fp-ts": "^2.0.0",
+    "fp-ts-contrib": "^0.1.17",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
Closes #24. Adds an example for parsing a command line statement into a command and its associated arguments as discussed in #24.