### PR TITLE
Support `bind` and `bindTo` for `Parser` monad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.6.8
+
+- **New Feature**
+  - Add "do notation" to `Parser` monad (@CYBAI)
+
 # 0.6.7
 
 - **New Feature**

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -65,6 +65,9 @@ Added in v0.6.0
   - [parser](#parser)
 - [model](#model)
   - [Parser (interface)](#parser-interface)
+- [utils](#utils)
+  - [bind](#bind)
+  - [bindTo](#bindto)
 
 ---
 
@@ -637,3 +640,28 @@ export interface Parser<I, A> {
 ```
 
 Added in v0.6.0
+
+# utils
+
+## bind
+
+**Signature**
+
+```ts
+export declare const bind: <N extends string, I, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Parser<I, B>
+) => (fa: Parser<I, A>) => Parser<I, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.6.8
+
+## bindTo
+
+**Signature**
+
+```ts
+export declare const bindTo: <N extends string>(name: N) => <I, A>(fa: Parser<I, A>) => Parser<I, { [K in N]: A }>
+```
+
+Added in v0.6.8

--- a/examples/command.ts
+++ b/examples/command.ts
@@ -33,7 +33,6 @@
  * For example, one could generalize the parser exemplified below to accept any command. Then, the
  * structure of the parsed AST for specific commands can be enforced using instances of `io-ts` `Schema`s.
  */
-import { Do } from 'fp-ts-contrib/lib/Do'
 import * as A from 'fp-ts/lib/Array'
 import { mapLeft, Either } from 'fp-ts/lib/Either'
 import { getStructMonoid, Monoid } from 'fp-ts/lib/Monoid'
@@ -173,10 +172,11 @@ const positional: P.Parser<string, Positional> = pipe(C.many1(C.notSpace), P.map
 const argument = P.either<string, Argument>(flag, () => P.either<string, Argument>(named, () => positional))
 
 const statement = (cmd: string) =>
-  Do(P.parser)
-    .bind('command', whitespaceSurrounded(S.string(cmd)))
-    .bind('args', P.many(whitespaceSurrounded(argument)))
-    .done()
+  pipe(
+    whitespaceSurrounded(S.string(cmd)),
+    P.bindTo('command'),
+    P.bind('args', () => P.many(whitespaceSurrounded(argument)))
+  )
 
 const ast = (command: string, source: string): P.Parser<string, Ast> => {
   return pipe(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parser-ts",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,12 +2226,6 @@
       "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ==",
       "dev": true
     },
-    "fp-ts-contrib": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/fp-ts-contrib/-/fp-ts-contrib-0.1.17.tgz",
-      "integrity": "sha512-UBQ7AdGp0GktLkIn3e6npVIfLm1ZM+racizgVqL88j6HBLBoBjRtVjIxRIS6YbNypuP94ngaZpy2SEib9lnZ9A==",
-      "dev": true
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "docs-ts": "^0.5.1",
     "dtslint": "^0.4.2",
     "fp-ts": "^2.0.0",
-    "fp-ts-contrib": "^0.1.17",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",
     "mocha": "^5.2.0",

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -577,3 +577,41 @@ export const parser: Monad2<URI> & Alternative2<URI> = {
   alt: alt_,
   zero: fail
 }
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+/**
+ * @internal
+ */
+const bind_ = <A, N extends string, B>(
+  a: A,
+  name: Exclude<N, keyof A>,
+  b: B
+): { [K in keyof A | N]: K extends keyof A ? A[K] : B } => Object.assign({}, a, { [name]: b }) as any
+
+/**
+ * @since 0.6.8
+ */
+export const bindTo = <N extends string>(name: N) => <I, A>(fa: Parser<I, A>): Parser<I, { [K in N]: A }> =>
+  pipe(
+    fa,
+    map(a => bind_({}, name, a))
+  )
+
+/**
+ * @since 0.6.8
+ */
+export const bind = <N extends string, I, A, B>(name: Exclude<N, keyof A>, f: (a: A) => Parser<I, B>) => (
+  fa: Parser<I, A>
+): Parser<I, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
+  pipe(
+    fa,
+    chain(a =>
+      pipe(
+        f(a),
+        map(b => bind_(a, name, b))
+      )
+    )
+  )


### PR DESCRIPTION
Hi @gcanti, while upgrading a private repo to use `bind` and `bindTo` introduced in `fp-ts@2.8.1`, I just noticed that `parser-ts` doesn't support these two methods.

I wonder if it's good to also introduce them to `parser-ts`? Also, with introducing `bind` and `bindTo` to `Parser` monad, we're able to drop the `fp-ts-contrib` dependency for the `examples/command.ts` in this repo.

Also, if this PR is acceptable, should I update the `package.json` version in this PR? or it will be handled while publishing?

Thank you! 🙇 