### PR TITLE
expose test helper run in library

### DIFF
--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -21,6 +21,7 @@ Added in v0.6.0
   - [maybe](#maybe)
   - [notSpaces](#notspaces)
   - [notSpaces1](#notspaces1)
+  - [run](#run)
   - [spaces](#spaces)
   - [spaces1](#spaces1)
 - [constructors](#constructors)
@@ -126,6 +127,16 @@ export declare const notSpaces1: P.Parser<string, string>
 ```
 
 Added in v0.6.0
+
+## run
+
+**Signature**
+
+```ts
+export declare function run(string: string): <A>(p: P.Parser<C.Char, A>) => PR.ParseResult<C.Char, A>
+```
+
+Added in v0.6.8
 
 ## spaces
 

--- a/src/string.ts
+++ b/src/string.ts
@@ -10,6 +10,8 @@ import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as C from './char'
 import * as P from './Parser'
+import * as S from './Stream'
+import * as PR from './ParseResult'
 
 // -------------------------------------------------------------------------------------
 // constructors
@@ -179,3 +181,14 @@ export const float: P.Parser<C.Char, number> = P.expected(
 export const doubleQuotedString: P.Parser<string, String> = P.surroundedBy(C.char('"'))(
   many(P.either(string('\\"'), () => C.notChar('"')))
 )
+
+/**
+ * @summary
+ * Creates a stream from `string` and runs the parser.
+ *
+ * @category combinators
+ * @since 0.6.8
+ */
+export function run(string: string): <A>(p: P.Parser<C.Char, A>) => PR.ParseResult<C.Char, A> {
+  return p => p(S.stream(string.split('')))
+}

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -5,62 +5,64 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { char as C, parser as P, string as S } from '../src'
 import { error, success } from '../src/ParseResult'
 import { stream } from '../src/Stream'
-import { run } from './helpers'
 
 describe('Parser', () => {
   it('eof', () => {
     const parser = P.eof<C.Char>()
-    assert.deepStrictEqual(run(parser, ''), success(undefined, stream([]), stream([])))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['end of file']))
+    assert.deepStrictEqual(S.run('')(parser), success(undefined, stream([]), stream([])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['end of file']))
   })
 
   it('cut', () => {
     const parser = P.cut(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'ab'), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'bb'), error(stream(['b', 'b']), ['"a"'], true))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bb')(parser), error(stream(['b', 'b']), ['"a"'], true))
   })
 
   it('either', () => {
     const parser1 = P.either(C.char('a'), () => C.char('b'))
-    assert.deepStrictEqual(run(parser1, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser1, 'b'), success('b', stream(['b'], 1), stream(['b'])))
-    assert.deepStrictEqual(run(parser1, 'c'), error(stream(['c']), ['"a"', '"b"']))
+    assert.deepStrictEqual(S.run('a')(parser1), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('b')(parser1), success('b', stream(['b'], 1), stream(['b'])))
+    assert.deepStrictEqual(S.run('c')(parser1), error(stream(['c']), ['"a"', '"b"']))
+
     const parser2 = P.either(P.cut(C.char('a')), () => C.char('b'))
-    assert.deepStrictEqual(run(parser2, 'c'), error(stream(['c']), ['"a"'], true))
+    assert.deepStrictEqual(S.run('c')(parser2), error(stream(['c']), ['"a"'], true))
+
     const parser3 = P.either(S.string('aa'), () => C.char('b'))
-    assert.deepStrictEqual(run(parser3, 'ab'), error(stream(['a', 'b'], 1), ['"aa"']))
+    assert.deepStrictEqual(S.run('ab')(parser3), error(stream(['a', 'b'], 1), ['"aa"']))
+
     const parser4 = P.either(C.char('a'), () => S.string('bb'))
-    assert.deepStrictEqual(run(parser4, 'bc'), error(stream(['b', 'c'], 1), ['"bb"']))
+    assert.deepStrictEqual(S.run('bc')(parser4), error(stream(['b', 'c'], 1), ['"bb"']))
   })
 
   it('map', () => {
     const parser = P.map(() => 'b')(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'a'), success('b', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('a')(parser), success('b', stream(['a'], 1), stream(['a'])))
   })
 
   it('ap', () => {
     const parser = P.ap(C.char('a'))(P.of(s => s.length))
-    assert.deepStrictEqual(run(parser, 'a'), success(1, stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('a')(parser), success(1, stream(['a'], 1), stream(['a'])))
   })
 
   it('apFirst', () => {
     const parser = P.apFirst(S.spaces)(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'a '), success('a', stream(['a', ' '], 2), stream(['a', ' '])))
+    assert.deepStrictEqual(S.run('a ')(parser), success('a', stream(['a', ' '], 2), stream(['a', ' '])))
   })
 
   it('apSecond', () => {
     const parser = P.apSecond(S.spaces)(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'a '), success(' ', stream(['a', ' '], 2), stream(['a', ' '])))
+    assert.deepStrictEqual(S.run('a ')(parser), success(' ', stream(['a', ' '], 2), stream(['a', ' '])))
   })
 
   it('flatten', () => {
     const parser = P.of<string, P.Parser<string, string>>(C.char('a'))
-    assert.deepStrictEqual(run(P.flatten(parser), 'a'), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('a')(P.flatten(parser)), success('a', stream(['a'], 1), stream(['a'])))
   })
 
   it('cutWith', () => {
     const parser = P.cutWith(C.char('a'), C.char('b'))
-    assert.deepStrictEqual(run(parser, 'ac'), error(stream(['a', 'c'], 1), ['"b"'], true))
+    assert.deepStrictEqual(S.run('ac')(parser), error(stream(['a', 'c'], 1), ['"b"'], true))
   })
 
   it('sepBy', () => {
@@ -68,42 +70,48 @@ describe('Parser', () => {
       C.char(','),
       P.sat(c => c !== ',')
     )
-    assert.deepStrictEqual(run(parser, ''), success([], stream([]), stream([])))
-    assert.deepStrictEqual(run(parser, 'a'), success(['a'], stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'a,b'), success(['a', 'b'], stream(['a', ',', 'b'], 3), stream(['a', ',', 'b'])))
+    assert.deepStrictEqual(S.run('')(parser), success([], stream([]), stream([])))
+    assert.deepStrictEqual(S.run('a')(parser), success(['a'], stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(
+      S.run('a,b')(parser),
+      success(['a', 'b'], stream(['a', ',', 'b'], 3), stream(['a', ',', 'b']))
+    )
   })
 
   it('sepBy1', () => {
     const parser = P.sepBy1(C.char(','), C.char('a'))
-    assert.deepStrictEqual(run(parser, ''), error(stream([]), ['"a"']))
-    assert.deepStrictEqual(run(parser, 'a,b'), success(['a'], stream(['a', ',', 'b'], 1), stream(['a', ',', 'b'])))
+    assert.deepStrictEqual(S.run('')(parser), error(stream([]), ['"a"']))
+    assert.deepStrictEqual(S.run('a,b')(parser), success(['a'], stream(['a', ',', 'b'], 1), stream(['a', ',', 'b'])))
   })
 
   it('sepByCut', () => {
     const parser = P.sepByCut(C.char(','), C.char('a'))
-    assert.deepStrictEqual(run(parser, 'a,b'), error(stream(['a', ',', 'b'], 2), ['"a"'], true))
-    assert.deepStrictEqual(run(parser, 'a,a'), success(['a', 'a'], stream(['a', ',', 'a'], 3), stream(['a', ',', 'a'])))
+    assert.deepStrictEqual(S.run('a,b')(parser), error(stream(['a', ',', 'b'], 2), ['"a"'], true))
+    assert.deepStrictEqual(
+      S.run('a,a')(parser),
+      success(['a', 'a'], stream(['a', ',', 'a'], 3), stream(['a', ',', 'a']))
+    )
   })
 
   it('filter', () => {
     const parser = P.expected(P.filter((c: C.Char) => c !== 'a')(P.item<C.Char>()), 'anything except "a"')
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['anything except "a"']))
-    assert.deepStrictEqual(run(parser, 'b'), success('b', stream(['b'], 1), stream(['b'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['anything except "a"']))
+    assert.deepStrictEqual(S.run('b')(parser), success('b', stream(['b'], 1), stream(['b'])))
   })
 
   describe('between', () => {
     it('monomorphic', () => {
       const betweenParens = P.between(C.char('('), C.char(')'))
       const parser = betweenParens(C.char('a'))
-      assert.deepStrictEqual(run(parser, '(a'), error(stream(['(', 'a'], 2), ['")"']))
-      assert.deepStrictEqual(run(parser, '(a)'), success('a', stream(['(', 'a', ')'], 3), stream(['(', 'a', ')'])))
+      assert.deepStrictEqual(S.run('(a')(parser), error(stream(['(', 'a'], 2), ['")"']))
+      assert.deepStrictEqual(S.run('(a)')(parser), success('a', stream(['(', 'a', ')'], 3), stream(['(', 'a', ')'])))
     })
 
     it('polymorphic', () => {
       const betweenParens = P.between(C.char('('), C.char(')'))
       const parser = betweenParens(S.int)
-      assert.deepStrictEqual(run(parser, '(1'), error(stream(['(', '1'], 2), ['")"']))
-      assert.deepStrictEqual(run(parser, '(1)'), success(1, stream(['(', '1', ')'], 3), stream(['(', '1', ')'])))
+      assert.deepStrictEqual(S.run('(1')(parser), error(stream(['(', '1'], 2), ['")"']))
+      assert.deepStrictEqual(S.run('(1)')(parser), success(1, stream(['(', '1', ')'], 3), stream(['(', '1', ')'])))
     })
   })
 
@@ -111,52 +119,55 @@ describe('Parser', () => {
     it('monomorphic', () => {
       const surroundedByPipes = P.surroundedBy(C.char('|'))
       const parser = surroundedByPipes(C.char('a'))
-      assert.deepStrictEqual(run(parser, '|a'), error(stream(['|', 'a'], 2), ['"|"']))
-      assert.deepStrictEqual(run(parser, '|a|'), success('a', stream(['|', 'a', '|'], 3), stream(['|', 'a', '|'])))
+      assert.deepStrictEqual(S.run('|a')(parser), error(stream(['|', 'a'], 2), ['"|"']))
+      assert.deepStrictEqual(S.run('|a|')(parser), success('a', stream(['|', 'a', '|'], 3), stream(['|', 'a', '|'])))
     })
 
     it('polymorphic', () => {
       const surroundedByPipes = P.surroundedBy(C.char('|'))
       const parser = surroundedByPipes(S.int)
-      assert.deepStrictEqual(run(parser, '|1'), error(stream(['|', '1'], 2), ['"|"']))
-      assert.deepStrictEqual(run(parser, '|1|'), success(1, stream(['|', '1', '|'], 3), stream(['|', '1', '|'])))
+      assert.deepStrictEqual(S.run('|1')(parser), error(stream(['|', '1'], 2), ['"|"']))
+      assert.deepStrictEqual(S.run('|1|')(parser), success(1, stream(['|', '1', '|'], 3), stream(['|', '1', '|'])))
     })
   })
 
   it('lookAhead', () => {
     const parser = S.fold([S.string('a'), P.lookAhead(S.string('b')), S.string('b')])
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a'], 1), ['"b"']))
-    assert.deepStrictEqual(run(parser, 'ab'), success('abb', stream(['a', 'b'], 2), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a'], 1), ['"b"']))
+    assert.deepStrictEqual(S.run('ab')(parser), success('abb', stream(['a', 'b'], 2), stream(['a', 'b'])))
   })
 
   it('takeUntil', () => {
     const parser = P.takeUntil((char: C.Char) => char === 'c')
-    assert.deepStrictEqual(run(parser, 'ab'), success(['a', 'b'], stream(['a', 'b'], 2), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'abc'), success(['a', 'b'], stream(['a', 'b', 'c'], 2), stream(['a', 'b', 'c'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success(['a', 'b'], stream(['a', 'b'], 2), stream(['a', 'b'])))
+    assert.deepStrictEqual(
+      S.run('abc')(parser),
+      success(['a', 'b'], stream(['a', 'b', 'c'], 2), stream(['a', 'b', 'c']))
+    )
   })
 
   it('optional', () => {
     const parser = P.optional(P.sat((char: C.Char) => char === 'a'))
-    assert.deepStrictEqual(run(parser, 'a'), success(some('a'), stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'b'), success(none, stream(['b'], 0), stream(['b'])))
+    assert.deepStrictEqual(S.run('a')(parser), success(some('a'), stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('b')(parser), success(none, stream(['b'], 0), stream(['b'])))
   })
 
   it('manyTill', () => {
     const parser = P.manyTill(C.letter, C.char('-'))
-    assert.deepStrictEqual(run(parser, 'a1-'), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
-    assert.deepStrictEqual(run(parser, '-'), success([], stream(['-'], 1), stream(['-'])))
+    assert.deepStrictEqual(S.run('a1-')(parser), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
+    assert.deepStrictEqual(S.run('-')(parser), success([], stream(['-'], 1), stream(['-'])))
     assert.deepStrictEqual(
-      run(parser, 'abc-'),
+      S.run('abc-')(parser),
       success(['a', 'b', 'c'], stream(['a', 'b', 'c', '-'], 4), stream(['a', 'b', 'c', '-']))
     )
   })
 
   it('many1Till', () => {
     const parser = P.many1Till(C.letter, C.char('-'))
-    assert.deepStrictEqual(run(parser, 'a1-'), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
-    assert.deepStrictEqual(run(parser, '-'), error(stream(['-'], 0), ['a letter']))
+    assert.deepStrictEqual(S.run('a1-')(parser), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
+    assert.deepStrictEqual(S.run('-')(parser), error(stream(['-'], 0), ['a letter']))
     assert.deepStrictEqual(
-      run(parser, 'abc-'),
+      S.run('abc-')(parser),
       success(['a', 'b', 'c'], stream(['a', 'b', 'c', '-'], 4), stream(['a', 'b', 'c', '-']))
     )
   })
@@ -168,8 +179,8 @@ describe('Parser', () => {
       P.bind('b', () => C.char('b')),
       P.map(({ a, b }) => [a, b])
     )
-    assert.deepStrictEqual(run(parser, 'ab'), success(['a', 'b'], stream(['a', 'b'], 2), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'bc'), error(stream(['b', 'c'], 0), ['"a"']))
+    assert.deepStrictEqual(S.run('ab')(parser), success(['a', 'b'], stream(['a', 'b'], 2), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bc')(parser), error(stream(['b', 'c'], 0), ['"a"']))
   })
 
   it('bindTo', () => {
@@ -178,7 +189,7 @@ describe('Parser', () => {
       P.bindTo('headingA'),
       P.map(({ headingA }) => [headingA])
     )
-    assert.deepStrictEqual(run(parser, 'ab'), success(['a'], stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'bc'), error(stream(['b', 'c'], 0), ['"a"']))
+    assert.deepStrictEqual(S.run('ab')(parser), success(['a'], stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bc')(parser), error(stream(['b', 'c'], 0), ['"a"']))
   })
 })

--- a/test/char.ts
+++ b/test/char.ts
@@ -1,81 +1,85 @@
 import * as assert from 'assert'
-import { char as C } from '../src'
+import { char as C, string as S } from '../src'
 import { error, success } from '../src/ParseResult'
 import { stream } from '../src/Stream'
-import { run } from './helpers'
 
 describe('char', () => {
   it('char', () => {
     const parser = C.char('a')
-    assert.deepStrictEqual(run(parser, 'ab'), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'bb'), error(stream(['b', 'b']), ['"a"']))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bb')(parser), error(stream(['b', 'b']), ['"a"']))
+  })
+
+  it('run', () => {
+    const parser = C.char('a')
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
   })
 
   it('many', () => {
     const parser = C.many(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'b'), success('', stream(['b']), stream(['b'])))
-    assert.deepStrictEqual(run(parser, 'ab'), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'aab'), success('aa', stream(['a', 'a', 'b'], 2), stream(['a', 'a', 'b'])))
+    assert.deepStrictEqual(S.run('b')(parser), success('', stream(['b']), stream(['b'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('aab')(parser), success('aa', stream(['a', 'a', 'b'], 2), stream(['a', 'a', 'b'])))
   })
 
   it('many1', () => {
     const parser = C.many1(C.char('a'))
-    assert.deepStrictEqual(run(parser, 'b'), error(stream(['b']), ['"a"']))
-    assert.deepStrictEqual(run(parser, 'ab'), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'aab'), success('aa', stream(['a', 'a', 'b'], 2), stream(['a', 'a', 'b'])))
+    assert.deepStrictEqual(S.run('b')(parser), error(stream(['b']), ['"a"']))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('aab')(parser), success('aa', stream(['a', 'a', 'b'], 2), stream(['a', 'a', 'b'])))
   })
 
   it('notChar', () => {
     const parser = C.notChar('a')
-    assert.deepStrictEqual(run(parser, 'b'), success('b', stream(['b'], 1), stream(['b'])))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['anything but "a"']))
+    assert.deepStrictEqual(S.run('b')(parser), success('b', stream(['b'], 1), stream(['b'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['anything but "a"']))
   })
 
   it('oneOf', () => {
     const parser = C.oneOf('ab')
-    assert.deepStrictEqual(run(parser, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'b'), success('b', stream(['b'], 1), stream(['b'])))
-    assert.deepStrictEqual(run(parser, 'c'), error(stream(['c']), ['One of "ab"']))
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('b')(parser), success('b', stream(['b'], 1), stream(['b'])))
+    assert.deepStrictEqual(S.run('c')(parser), error(stream(['c']), ['One of "ab"']))
   })
 
   it('digit', () => {
     const parser = C.digit
-    assert.deepStrictEqual(run(parser, '1'), success('1', stream(['1'], 1), stream(['1'])))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['a digit']))
+    assert.deepStrictEqual(S.run('1')(parser), success('1', stream(['1'], 1), stream(['1'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['a digit']))
   })
 
   it('space', () => {
     const parser = C.space
-    assert.deepStrictEqual(run(parser, ' '), success(' ', stream([' '], 1), stream([' '])))
-    assert.deepStrictEqual(run(parser, '\t'), success('\t', stream(['\t'], 1), stream(['\t'])))
-    assert.deepStrictEqual(run(parser, '\n'), success('\n', stream(['\n'], 1), stream(['\n'])))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['a whitespace']))
+    assert.deepStrictEqual(S.run(' ')(parser), success(' ', stream([' '], 1), stream([' '])))
+    assert.deepStrictEqual(S.run('\t')(parser), success('\t', stream(['\t'], 1), stream(['\t'])))
+    assert.deepStrictEqual(S.run('\n')(parser), success('\n', stream(['\n'], 1), stream(['\n'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['a whitespace']))
   })
 
   it('alphanum', () => {
     const parser = C.alphanum
-    assert.deepStrictEqual(run(parser, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, '1'), success('1', stream(['1'], 1), stream(['1'])))
-    assert.deepStrictEqual(run(parser, '_'), success('_', stream(['_'], 1), stream(['_'])))
-    assert.deepStrictEqual(run(parser, '@'), error(stream(['@']), ['a word character']))
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('1')(parser), success('1', stream(['1'], 1), stream(['1'])))
+    assert.deepStrictEqual(S.run('_')(parser), success('_', stream(['_'], 1), stream(['_'])))
+    assert.deepStrictEqual(S.run('@')(parser), error(stream(['@']), ['a word character']))
   })
 
   it('upper', () => {
     const parser = C.upper
-    assert.deepStrictEqual(run(parser, 'A'), success('A', stream(['A'], 1), stream(['A'])))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['an upper case letter']))
+    assert.deepStrictEqual(S.run('A')(parser), success('A', stream(['A'], 1), stream(['A'])))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['an upper case letter']))
   })
 
   it('lower', () => {
     const parser = C.lower
-    assert.deepStrictEqual(run(parser, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'A'), error(stream(['A']), ['a lower case letter']))
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('A')(parser), error(stream(['A']), ['a lower case letter']))
   })
 
   it('notOneOf', () => {
     const parser = C.notOneOf('bc')
-    assert.deepStrictEqual(run(parser, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'b'), error(stream(['b']), ['Not one of "bc"']))
-    assert.deepStrictEqual(run(parser, 'c'), error(stream(['c']), ['Not one of "bc"']))
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('b')(parser), error(stream(['b']), ['Not one of "bc"']))
+    assert.deepStrictEqual(S.run('c')(parser), error(stream(['c']), ['Not one of "bc"']))
   })
 })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,0 @@
-import { Char } from '../src/char'
-import { ParseResult } from '../src/ParseResult'
-import { stream } from '../src/Stream'
-import { Parser } from '../src/Parser'
-
-export function run<A>(p: Parser<Char, A>, s: string): ParseResult<Char, A> {
-  return p(stream(s.split('')))
-}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -3,7 +3,7 @@ import { parser as P, string as S } from '../src'
 import { success, error } from '../src/ParseResult'
 import { stream } from '../src/Stream'
 import { pipe } from 'fp-ts/lib/pipeable'
-import { run } from './helpers'
+import { run } from '../src/string'
 
 export const pathParser = pipe(
   S.string('/users/'),
@@ -18,7 +18,7 @@ export const pathParser = pipe(
 describe('languages', () => {
   it('a parser for the path `/users/:user`', () => {
     assert.deepStrictEqual(
-      run(pathParser, '/users/1'),
+      run('/users/1')(pathParser),
       success(
         { user: 1 },
         stream(['/', 'u', 's', 'e', 'r', 's', '/', '1'], 8),
@@ -26,7 +26,7 @@ describe('languages', () => {
       )
     )
     assert.deepStrictEqual(
-      run(pathParser, '/users/a'),
+      run('/users/a')(pathParser),
       error(stream(['/', 'u', 's', 'e', 'r', 's', '/', 'a'], 7), ['an integer'])
     )
   })

--- a/test/string.ts
+++ b/test/string.ts
@@ -7,25 +7,24 @@ import * as RA from 'fp-ts/lib/ReadonlyArray'
 import { string as S } from '../src'
 import { error, success } from '../src/ParseResult'
 import { stream } from '../src/Stream'
-import { run } from './helpers'
 
 describe('string', () => {
   describe('string', () => {
     it('should parse an empty string', () => {
       const parser = S.string('')
 
-      assert.deepStrictEqual(run(parser, 'foo'), success('', stream(['f', 'o', 'o'], 0), stream(['f', 'o', 'o'])))
+      assert.deepStrictEqual(S.run('foo')(parser), success('', stream(['f', 'o', 'o'], 0), stream(['f', 'o', 'o'])))
     })
 
     it('should parse a non-empty string', () => {
       const parser = S.string('foo')
 
-      assert.deepStrictEqual(run(parser, 'foo'), success('foo', stream(['f', 'o', 'o'], 3), stream(['f', 'o', 'o'])))
+      assert.deepStrictEqual(S.run('foo')(parser), success('foo', stream(['f', 'o', 'o'], 3), stream(['f', 'o', 'o'])))
       assert.deepStrictEqual(
-        run(parser, 'foobar'),
+        S.run('foobar')(parser),
         success('foo', stream(['f', 'o', 'o', 'b', 'a', 'r'], 3), stream(['f', 'o', 'o', 'b', 'a', 'r']))
       )
-      assert.deepStrictEqual(run(parser, 'barfoo'), error(stream(['b', 'a', 'r', 'f', 'o', 'o']), ['"foo"']))
+      assert.deepStrictEqual(S.run('barfoo')(parser), error(stream(['b', 'a', 'r', 'f', 'o', 'o']), ['"foo"']))
     })
 
     it('should handle long strings without exceeding the recursion limit (#41)', () => {
@@ -36,7 +35,7 @@ describe('string', () => {
       const parser = S.string(target)
 
       assert.deepStrictEqual(
-        run(parser, source),
+        S.run(source)(parser),
         success(target, stream(source.split(''), cursor), stream(source.split('')))
       )
     })
@@ -44,86 +43,86 @@ describe('string', () => {
 
   it('many', () => {
     const parser = S.many(S.string('ab'))
-    assert.deepStrictEqual(run(parser, 'ab'), success('ab', stream(['a', 'b'], 2), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success('ab', stream(['a', 'b'], 2), stream(['a', 'b'])))
     assert.deepStrictEqual(
-      run(parser, 'abab'),
+      S.run('abab')(parser),
       success('abab', stream(['a', 'b', 'a', 'b'], 4), stream(['a', 'b', 'a', 'b']))
     )
-    assert.deepStrictEqual(run(parser, 'aba'), success('ab', stream(['a', 'b', 'a'], 2), stream(['a', 'b', 'a'])))
-    assert.deepStrictEqual(run(parser, 'ac'), success('', stream(['a', 'c']), stream(['a', 'c'])))
+    assert.deepStrictEqual(S.run('aba')(parser), success('ab', stream(['a', 'b', 'a'], 2), stream(['a', 'b', 'a'])))
+    assert.deepStrictEqual(S.run('ac')(parser), success('', stream(['a', 'c']), stream(['a', 'c'])))
   })
 
   it('oneOf', () => {
     const parser = S.oneOf(array)(['a', 'b'])
-    assert.deepStrictEqual(run(parser, 'a'), success('a', stream(['a'], 1), stream(['a'])))
-    assert.deepStrictEqual(run(parser, 'ab'), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
-    assert.deepStrictEqual(run(parser, 'ba'), success('b', stream(['b', 'a'], 1), stream(['b', 'a'])))
-    assert.deepStrictEqual(run(parser, 'ca'), error(stream(['c', 'a']), ['"a"', '"b"']))
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('ba')(parser), success('b', stream(['b', 'a'], 1), stream(['b', 'a'])))
+    assert.deepStrictEqual(S.run('ca')(parser), error(stream(['c', 'a']), ['"a"', '"b"']))
   })
 
   it('int', () => {
     const parser = S.int
-    assert.deepStrictEqual(run(parser, '1'), success(1, stream(['1'], 1), stream(['1'])))
-    assert.deepStrictEqual(run(parser, '-1'), success(-1, stream(['-', '1'], 2), stream(['-', '1'])))
-    assert.deepStrictEqual(run(parser, '10'), success(10, stream(['1', '0'], 2), stream(['1', '0'])))
-    assert.deepStrictEqual(run(parser, '-10'), success(-10, stream(['-', '1', '0'], 3), stream(['-', '1', '0'])))
-    assert.deepStrictEqual(run(parser, '0.1'), success(0, stream(['0', '.', '1'], 1), stream(['0', '.', '1'])))
+    assert.deepStrictEqual(S.run('1')(parser), success(1, stream(['1'], 1), stream(['1'])))
+    assert.deepStrictEqual(S.run('-1')(parser), success(-1, stream(['-', '1'], 2), stream(['-', '1'])))
+    assert.deepStrictEqual(S.run('10')(parser), success(10, stream(['1', '0'], 2), stream(['1', '0'])))
+    assert.deepStrictEqual(S.run('-10')(parser), success(-10, stream(['-', '1', '0'], 3), stream(['-', '1', '0'])))
+    assert.deepStrictEqual(S.run('0.1')(parser), success(0, stream(['0', '.', '1'], 1), stream(['0', '.', '1'])))
     assert.deepStrictEqual(
-      run(parser, '-0.1'),
+      S.run('-0.1')(parser),
       success(-0, stream(['-', '0', '.', '1'], 2), stream(['-', '0', '.', '1']))
     )
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['an integer']))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['an integer']))
   })
 
   it('float', () => {
     const parser = S.float
-    assert.deepStrictEqual(run(parser, '1'), success(1, stream(['1'], 1), stream(['1'])))
-    assert.deepStrictEqual(run(parser, '-1'), success(-1, stream(['-', '1'], 2), stream(['-', '1'])))
-    assert.deepStrictEqual(run(parser, '10'), success(10, stream(['1', '0'], 2), stream(['1', '0'])))
-    assert.deepStrictEqual(run(parser, '-10'), success(-10, stream(['-', '1', '0'], 3), stream(['-', '1', '0'])))
-    assert.deepStrictEqual(run(parser, '0.1'), success(0.1, stream(['0', '.', '1'], 3), stream(['0', '.', '1'])))
+    assert.deepStrictEqual(S.run('1')(parser), success(1, stream(['1'], 1), stream(['1'])))
+    assert.deepStrictEqual(S.run('-1')(parser), success(-1, stream(['-', '1'], 2), stream(['-', '1'])))
+    assert.deepStrictEqual(S.run('10')(parser), success(10, stream(['1', '0'], 2), stream(['1', '0'])))
+    assert.deepStrictEqual(S.run('-10')(parser), success(-10, stream(['-', '1', '0'], 3), stream(['-', '1', '0'])))
+    assert.deepStrictEqual(S.run('0.1')(parser), success(0.1, stream(['0', '.', '1'], 3), stream(['0', '.', '1'])))
     assert.deepStrictEqual(
-      run(parser, '-0.1'),
+      S.run('-0.1')(parser),
       success(-0.1, stream(['-', '0', '.', '1'], 4), stream(['-', '0', '.', '1']))
     )
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['a float']))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['a float']))
   })
 
   it('doubleQuotedString', () => {
     const parser = S.doubleQuotedString
-    assert.deepStrictEqual(run(parser, '""'), success('', stream(['"', '"'], 2), stream(['"', '"'])))
-    assert.deepStrictEqual(run(parser, '"a"'), success('a', stream(['"', 'a', '"'], 3), stream(['"', 'a', '"'])))
+    assert.deepStrictEqual(S.run('""')(parser), success('', stream(['"', '"'], 2), stream(['"', '"'])))
+    assert.deepStrictEqual(S.run('"a"')(parser), success('a', stream(['"', 'a', '"'], 3), stream(['"', 'a', '"'])))
     assert.deepStrictEqual(
-      run(parser, '"ab"'),
+      S.run('"ab"')(parser),
       success('ab', stream(['"', 'a', 'b', '"'], 4), stream(['"', 'a', 'b', '"']))
     )
     assert.deepStrictEqual(
-      run(parser, '"ab"c'),
+      S.run('"ab"c')(parser),
       success('ab', stream(['"', 'a', 'b', '"', 'c'], 4), stream(['"', 'a', 'b', '"', 'c']))
     )
     assert.deepStrictEqual(
-      run(parser, '"a\\"b"'),
+      S.run('"a\\"b"')(parser),
       success('a\\"b', stream(['"', 'a', '\\', '"', 'b', '"'], 6), stream(['"', 'a', '\\', '"', 'b', '"']))
     )
   })
 
   it('spaces', () => {
     const parser = S.spaces
-    assert.deepStrictEqual(run(parser, ''), success('', stream([]), stream([])))
-    assert.deepStrictEqual(run(parser, ' '), success(' ', stream([' '], 1), stream([' '])))
-    assert.deepStrictEqual(run(parser, '\t'), success('\t', stream(['\t'], 1), stream(['\t'])))
-    assert.deepStrictEqual(run(parser, '\n'), success('\n', stream(['\n'], 1), stream(['\n'])))
-    assert.deepStrictEqual(run(parser, '\n\t'), success('\n\t', stream(['\n', '\t'], 2), stream(['\n', '\t'])))
-    assert.deepStrictEqual(run(parser, 'a'), success('', stream(['a']), stream(['a'])))
+    assert.deepStrictEqual(S.run('')(parser), success('', stream([]), stream([])))
+    assert.deepStrictEqual(S.run(' ')(parser), success(' ', stream([' '], 1), stream([' '])))
+    assert.deepStrictEqual(S.run('\t')(parser), success('\t', stream(['\t'], 1), stream(['\t'])))
+    assert.deepStrictEqual(S.run('\n')(parser), success('\n', stream(['\n'], 1), stream(['\n'])))
+    assert.deepStrictEqual(S.run('\n\t')(parser), success('\n\t', stream(['\n', '\t'], 2), stream(['\n', '\t'])))
+    assert.deepStrictEqual(S.run('a')(parser), success('', stream(['a']), stream(['a'])))
   })
 
   it('spaces1', () => {
     const parser = S.spaces1
-    assert.deepStrictEqual(run(parser, ' '), success(' ', stream([' '], 1), stream([' '])))
-    assert.deepStrictEqual(run(parser, '  '), success('  ', stream([' ', ' '], 2), stream([' ', ' '])))
-    assert.deepStrictEqual(run(parser, ' a'), success(' ', stream([' ', 'a'], 1), stream([' ', 'a'])))
-    assert.deepStrictEqual(run(parser, '\n\t'), success('\n\t', stream(['\n', '\t'], 2), stream(['\n', '\t'])))
-    assert.deepStrictEqual(run(parser, ''), error(stream([]), ['a whitespace']))
-    assert.deepStrictEqual(run(parser, 'a'), error(stream(['a']), ['a whitespace']))
+    assert.deepStrictEqual(S.run(' ')(parser), success(' ', stream([' '], 1), stream([' '])))
+    assert.deepStrictEqual(S.run('  ')(parser), success('  ', stream([' ', ' '], 2), stream([' ', ' '])))
+    assert.deepStrictEqual(S.run(' a')(parser), success(' ', stream([' ', 'a'], 1), stream([' ', 'a'])))
+    assert.deepStrictEqual(S.run('\n\t')(parser), success('\n\t', stream(['\n', '\t'], 2), stream(['\n', '\t'])))
+    assert.deepStrictEqual(S.run('')(parser), error(stream([]), ['a whitespace']))
+    assert.deepStrictEqual(S.run('a')(parser), error(stream(['a']), ['a whitespace']))
   })
 })


### PR DESCRIPTION
Did not export as a main module, as it's not really a module by fp-ts standards.

Instead, it can be access by `import { run } from "parser-ts/lib/helpers"`

I forgot to squash these, so feel free to squash these on merge.

closes #33 