### PR TITLE
Feature: manyTill and many1Till 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.6.11
+
+- **New Feature**
+  - add `ChainRec` instance for `Parser` (@IMax153)
+  - add `manyTill` and `many1Till` to `Parser` module (@IMax153)
+
 # 0.6.10
 
 - **New Feature**

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -40,6 +40,8 @@ Added in v0.6.0
   - [lookAhead](#lookahead)
   - [many](#many)
   - [many1](#many1)
+  - [many1Till](#many1till)
+  - [manyTill](#manytill)
   - [maybe](#maybe)
   - [optional](#optional)
   - [sepBy](#sepby)
@@ -58,6 +60,7 @@ Added in v0.6.0
   - [Alt](#alt-1)
   - [Alternative](#alternative-1)
   - [Applicative](#applicative-1)
+  - [ChainRec](#chainrec)
   - [Functor](#functor-1)
   - [Monad](#monad-1)
   - [URI](#uri)
@@ -382,6 +385,38 @@ export declare const many1: <I, A>(p: Parser<I, A>) => Parser<I, NEA.NonEmptyArr
 
 Added in v0.6.0
 
+## many1Till
+
+The `many1Till` combinator is just like the `manyTill` combinator, except it
+requires the value `parser` to match at least once before the `terminator`
+parser. The resulting list is thus guaranteed to contain at least one value.
+
+**Signature**
+
+```ts
+export declare const many1Till: <I, A, B>(
+  parser: Parser<I, A>,
+  terminator: Parser<I, B>
+) => Parser<I, RNEA.ReadonlyNonEmptyArray<A>>
+```
+
+Added in v0.6.11
+
+## manyTill
+
+The `manyTill` combinator takes a value `parser` and a `terminator` parser, and
+returns a new parser that will run the value `parser` repeatedly on the input
+stream, returning a list of the result values of each parse operation as its
+result, or the empty list if the parser never succeeded.
+
+**Signature**
+
+```ts
+export declare const manyTill: <I, A, B>(parser: Parser<I, A>, terminator: Parser<I, B>) => Parser<I, readonly A[]>
+```
+
+Added in v0.6.11
+
 ## maybe
 
 The `maybe` parser combinator creates a parser which will run the provided
@@ -625,6 +660,16 @@ export declare const Applicative: Applicative2<'Parser'>
 ```
 
 Added in v0.6.7
+
+## ChainRec
+
+**Signature**
+
+```ts
+export declare const ChainRec: ChainRec2<'Parser'>
+```
+
+Added in v0.6.11
 
 ## Functor
 

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -400,6 +400,22 @@ export declare const many1Till: <I, A, B>(
 ) => Parser<I, RNEA.ReadonlyNonEmptyArray<A>>
 ```
 
+**Example**
+
+```ts
+import * as C from 'parser-ts/char'
+import { run } from 'parser-ts/code-frame'
+import * as P from 'parser-ts/Parser'
+
+const parser = P.many1Till(C.letter, C.char('-'))
+
+run(parser, 'abc-')
+// { _tag: 'Right', right: [ 'a', 'b', 'c' ] }
+
+run(parser, '-')
+// { _tag: 'Left', left: '> 1 | -\n    | ^ Expected: a letter' }
+```
+
 Added in v0.6.11
 
 ## manyTill
@@ -413,6 +429,22 @@ result, or the empty list if the parser never succeeded.
 
 ```ts
 export declare const manyTill: <I, A, B>(parser: Parser<I, A>, terminator: Parser<I, B>) => Parser<I, readonly A[]>
+```
+
+**Example**
+
+```ts
+import * as C from 'parser-ts/char'
+import { run } from 'parser-ts/code-frame'
+import * as P from 'parser-ts/Parser'
+
+const parser = P.manyTill(C.letter, C.char('-'))
+
+run(parser, 'abc-')
+// { _tag: 'Right', right: [ 'a', 'b', 'c' ] }
+
+run(parser, '-')
+// { _tag: 'Right', right: [] }
 ```
 
 Added in v0.6.11

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -450,7 +450,17 @@ export const optional = <I, A>(parser: Parser<I, A>): Parser<I, O.Option<A>> =>
  * result, or the empty list if the parser never succeeded.
  *
  * @example
+ * import * as C from 'parser-ts/char'
+ * import { run } from 'parser-ts/code-frame'
+ * import * as P from 'parser-ts/Parser'
  *
+ * const parser = P.manyTill(C.letter, C.char('-'))
+ *
+ * run(parser, 'abc-')
+ * // { _tag: 'Right', right: [ 'a', 'b', 'c' ] }
+ *
+ * run(parser, '-')
+ * // { _tag: 'Right', right: [] }
  *
  * @category combinators
  * @since 0.6.11
@@ -468,7 +478,17 @@ export const manyTill = <I, A, B>(parser: Parser<I, A>, terminator: Parser<I, B>
  * parser. The resulting list is thus guaranteed to contain at least one value.
  *
  * @example
+ * import * as C from 'parser-ts/char'
+ * import { run } from 'parser-ts/code-frame'
+ * import * as P from 'parser-ts/Parser'
  *
+ * const parser = P.many1Till(C.letter, C.char('-'))
+ *
+ * run(parser, 'abc-')
+ * // { _tag: 'Right', right: [ 'a', 'b', 'c' ] }
+ *
+ * run(parser, '-')
+ * // { _tag: 'Left', left: '> 1 | -\n    | ^ Expected: a letter' }
  *
  * @category combinators
  * @since 0.6.11

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -141,6 +141,26 @@ describe('Parser', () => {
     assert.deepStrictEqual(run(parser, 'b'), success(none, stream(['b'], 0), stream(['b'])))
   })
 
+  it('manyTill', () => {
+    const parser = P.manyTill(C.letter, C.char('-'))
+    assert.deepStrictEqual(run(parser, 'a1-'), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
+    assert.deepStrictEqual(run(parser, '-'), success([], stream(['-'], 1), stream(['-'])))
+    assert.deepStrictEqual(
+      run(parser, 'abc-'),
+      success(['a', 'b', 'c'], stream(['a', 'b', 'c', '-'], 4), stream(['a', 'b', 'c', '-']))
+    )
+  })
+
+  it('many1Till', () => {
+    const parser = P.many1Till(C.letter, C.char('-'))
+    assert.deepStrictEqual(run(parser, 'a1-'), error(stream(['a', '1', '-'], 1), ['"-"', 'a letter']))
+    assert.deepStrictEqual(run(parser, '-'), error(stream(['-'], 0), ['a letter']))
+    assert.deepStrictEqual(
+      run(parser, 'abc-'),
+      success(['a', 'b', 'c'], stream(['a', 'b', 'c', '-'], 4), stream(['a', 'b', 'c', '-']))
+    )
+  })
+
   it('bind', () => {
     const parser = pipe(
       C.char('a'),


### PR DESCRIPTION
A summary of changes contained in this PR can be found below. Closes #38.

# 0.6.11

- **New Feature**
  - add `ChainRec` instance for `Parser` (@IMax153)
  - add `manyTill` and `many1Till` to `Parser` module (@IMax153)