### PR TITLE
Correct typing for `doubleQuotedString`

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -178,7 +178,7 @@ export const float: P.Parser<C.Char, number> = P.expected(
  * @category combinators
  * @since 0.6.0
  */
-export const doubleQuotedString: P.Parser<string, String> = P.surroundedBy(C.char('"'))(
+export const doubleQuotedString: P.Parser<string, string> = P.surroundedBy(C.char('"'))(
   many(P.either(string('\\"'), () => C.notChar('"')))
 )
 


### PR DESCRIPTION
Perhaps it's mistakenly capitalized, and this will cause a compilation error where you expect a primitive `string` value.

```
Type 'String' is not assignable to type 'string'.
  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
```