### PR TITLE
fix #47 P.either should fail with fatal error, if second parser faile…

### DIFF
--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -199,7 +199,10 @@ Matches the provided parser `p` that occurs between the provided `left` and `rig
 **Signature**
 
 ```ts
-export declare const between: <I, A>(left: Parser<I, A>, right: Parser<I, A>) => <B>(p: Parser<I, B>) => Parser<I, B>
+export declare const between: <I, A, B = A>(
+  left: Parser<I, A>,
+  right: Parser<I, B>
+) => <C>(p: Parser<I, C>) => Parser<I, C>
 ```
 
 Added in v0.6.4
@@ -487,7 +490,7 @@ run(parser, 'a')
 // { _tag: 'Right', right: { _tag: 'Some', value: 'a' } }
 
 run(parser, 'b')
-// { _tag: 'Left', left: { _tag: 'None' } }
+// { _tag: 'Right', right: { _tag: 'None' } }
 ```
 
 Added in v0.6.10

--- a/docs/modules/char.ts.md
+++ b/docs/modules/char.ts.md
@@ -28,6 +28,7 @@ Added in v0.6.0
   - [upper](#upper)
 - [constructors](#constructors)
   - [char](#char)
+  - [charC](#charc)
   - [notChar](#notchar)
   - [notOneOf](#notoneof)
   - [oneOf](#oneof)
@@ -212,6 +213,19 @@ export declare const char: (c: Char) => P.Parser<Char, Char>
 ```
 
 Added in v0.6.0
+
+## charC
+
+The `charC` parser constructor returns a parser which matches only the
+specified single character, case-insensitive
+
+**Signature**
+
+```ts
+export declare const charC: (c: Char) => P.Parser<Char, Char>
+```
+
+Added in v0.6.15
 
 ## notChar
 

--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -26,7 +26,9 @@ Added in v0.6.0
   - [spaces1](#spaces1)
 - [constructors](#constructors)
   - [oneOf](#oneof)
+  - [oneOfC](#oneofc)
   - [string](#string)
+  - [stringC](#stringc)
 - [destructors](#destructors)
   - [fold](#fold)
 
@@ -171,13 +173,52 @@ Matches one of a list of strings.
 **Signature**
 
 ```ts
-export declare function oneOf<F extends URIS>(
-  F: Functor1<F> & Foldable1<F>
-): (ss: Kind<F, string>) => P.Parser<C.Char, string>
-export declare function oneOf<F>(F: Functor<F> & Foldable<F>): (ss: HKT<F, string>) => P.Parser<C.Char, string>
+export declare const oneOf: {
+  <
+    U extends
+      | 'Option'
+      | 'ReadonlyRecord'
+      | 'Eq'
+      | 'Ord'
+      | 'NonEmptyArray'
+      | 'Array'
+      | 'ReadonlyNonEmptyArray'
+      | 'ReadonlyArray'
+  >(
+    F: Functor1<U> & Foldable1<U>
+  ): (ss: Kind<U, string>) => P.Parser<C.Char, string>
+  <U>(F: Functor<U> & Foldable<U>): (ss: HKT<U, string>) => P.Parser<C.Char, string>
+}
 ```
 
 Added in v0.6.0
+
+## oneOfC
+
+Matches one of a list of strings, case-insensitive.
+
+**Signature**
+
+```ts
+export declare const oneOfC: {
+  <
+    U extends
+      | 'Option'
+      | 'ReadonlyRecord'
+      | 'Eq'
+      | 'Ord'
+      | 'NonEmptyArray'
+      | 'Array'
+      | 'ReadonlyNonEmptyArray'
+      | 'ReadonlyArray'
+  >(
+    F: Functor1<U> & Foldable1<U>
+  ): (ss: Kind<U, string>) => P.Parser<C.Char, string>
+  <U>(F: Functor<U> & Foldable<U>): (ss: HKT<U, string>) => P.Parser<C.Char, string>
+}
+```
+
+Added in v0.6.15
 
 ## string
 
@@ -190,6 +231,18 @@ export declare const string: (s: string) => P.Parser<C.Char, string>
 ```
 
 Added in v0.6.0
+
+## stringC
+
+Matches the exact string provided, case-insensitive
+
+**Signature**
+
+```ts
+export declare const stringC: (s: string) => P.Parser<C.Char, string>
+```
+
+Added in v0.6.15
 
 # destructors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parser-ts",
-  "version": "0.6.12",
+  "version": "0.6.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ParseResult.ts
+++ b/src/ParseResult.ts
@@ -3,7 +3,7 @@
  */
 import { empty, getMonoid } from 'fp-ts/lib/Array'
 import { Either, left, right } from 'fp-ts/lib/Either'
-import { getFirstSemigroup, getLastSemigroup, getStructSemigroup, Semigroup } from 'fp-ts/lib/Semigroup'
+import { getFirstSemigroup, semigroupAny, getStructSemigroup, Semigroup } from 'fp-ts/lib/Semigroup'
 import { Stream } from './Stream'
 
 // -------------------------------------------------------------------------------------
@@ -103,12 +103,11 @@ export const extend = <I>(err1: ParseError<I>, err2: ParseError<I>): ParseError<
 
 const getSemigroup = <I>(): Semigroup<ParseError<I>> => ({
   concat: (x, y) => {
-    if (x.input.cursor < y.input.cursor) return getLastSemigroup<ParseError<I>>().concat(x, y)
-    if (x.input.cursor > y.input.cursor) return getFirstSemigroup<ParseError<I>>().concat(x, y)
-
+    if (x.input.cursor < y.input.cursor) return y
+    if (x.input.cursor > y.input.cursor) return x
     return getStructSemigroup<ParseError<I>>({
       input: getFirstSemigroup<Stream<I>>(),
-      fatal: getFirstSemigroup<boolean>(),
+      fatal: semigroupAny,
       expected: getMonoid<string>()
     }).concat(x, y)
   }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -180,7 +180,8 @@ export const either: <I, A>(p: Parser<I, A>, f: () => Parser<I, A>) => Parser<I,
     return e
   }
   return pipe(
-    f()(i),
+    i,
+    f(),
     E.mapLeft(err => extend(e.left, err))
   )
 }
@@ -265,13 +266,11 @@ export const many1: <I, A>(p: Parser<I, A>) => Parser<I, NEA.NonEmptyArray<A>> =
  * @category combinators
  * @since 0.6.0
  */
-export const sepBy = <I, A, B>(sep: Parser<I, A>, p: Parser<I, B>): Parser<I, Array<B>> => {
-  const nil: Parser<I, Array<B>> = of(A.empty)
-  return pipe(
+export const sepBy = <I, A, B>(sep: Parser<I, A>, p: Parser<I, B>): Parser<I, Array<B>> =>
+  pipe(
     sepBy1(sep, p),
-    alt(() => nil)
+    alt(() => of<I, Array<B>>(A.empty))
   )
-}
 
 /**
  * Matches the provided parser `p` one or more times, but requires the
@@ -353,7 +352,7 @@ export const filter: {
  * @category combinators
  * @since 0.6.4
  */
-export const between: <I, A>(left: Parser<I, A>, right: Parser<I, A>) => <B>(p: Parser<I, B>) => Parser<I, B> = (
+export const between: <I, A, B = A>(left: Parser<I, A>, right: Parser<I, B>) => <C>(p: Parser<I, C>) => Parser<I, C> = (
   left,
   right
 ) => p =>
@@ -431,7 +430,7 @@ export const takeUntil: <I>(predicate: Predicate<I>) => Parser<I, Array<I>> = pr
  * // { _tag: 'Right', right: { _tag: 'Some', value: 'a' } }
  *
  * run(parser, 'b')
- * // { _tag: 'Left', left: { _tag: 'None' } }
+ * // { _tag: 'Right', right: { _tag: 'None' } }
  *
  * @category combinators
  * @since 0.6.10
@@ -532,9 +531,7 @@ const map_: Monad2<URI>['map'] = (ma, f) => i =>
 const ap_: Monad2<URI>['ap'] = (mab, ma) => chain_(mab, f => map_(ma, f))
 const chain_: Chain2<URI>['chain'] = (ma, f) => seq(ma, f)
 const chainRec_: ChainRec2<URI>['chainRec'] = <I, A, B>(a: A, f: (a: A) => Parser<I, E.Either<A, B>>): Parser<I, B> => {
-  const split = (start: Stream<I>) => (
-    result: ParseSuccess<I, E.Either<A, B>>
-  ): E.Either<Next<I, A>, ParseResult<I, B>> =>
+  const split = (start: Stream<I>, result: ParseSuccess<I, E.Either<A, B>>): E.Either<Next<I, A>, ParseResult<I, B>> =>
     E.isLeft(result.value)
       ? E.left({ value: result.value.left, stream: result.next })
       : E.right(success(result.value.right, result.next, start))
@@ -544,7 +541,7 @@ const chainRec_: ChainRec2<URI>['chainRec'] = <I, A, B>(a: A, f: (a: A) => Parse
       if (E.isLeft(result)) {
         return E.right(error(state.stream, result.left.expected, result.left.fatal))
       }
-      return split(start)(result.right)
+      return split(start, result.right)
     })
 }
 const alt_: Alt2<URI>['alt'] = (fa, that) => either(fa, that)

--- a/src/char.ts
+++ b/src/char.ts
@@ -36,6 +36,16 @@ export const char: (c: Char) => P.Parser<Char, Char> = c =>
   )
 
 /**
+ * The `charC` parser constructor returns a parser which matches only the
+ * specified single character, case-insensitive
+ *
+ * @category constructors
+ * @since 0.6.15
+ */
+export const charC: (c: Char) => P.Parser<Char, Char> = c =>
+  P.either(char(c.toLowerCase()), () => char(c.toUpperCase()))
+
+/**
  * The `notChar` parser constructor makes a parser which will match any
  * single character other than the one provided.
  *

--- a/test/char.ts
+++ b/test/char.ts
@@ -7,7 +7,20 @@ describe('char', () => {
   it('char', () => {
     const parser = C.char('a')
     assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('Ab')(parser), error(stream(['A', 'b']), ['"a"']))
     assert.deepStrictEqual(S.run('bb')(parser), error(stream(['b', 'b']), ['"a"']))
+  })
+
+  it('charC', () => {
+    const parser = C.charC('a')
+    assert.deepStrictEqual(S.run('Ab')(parser), success('A', stream(['A', 'b'], 1), stream(['A', 'b'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bb')(parser), error(stream(['b', 'b']), ['"a"', '"A"']))
+
+    const parser2 = C.charC('A')
+    assert.deepStrictEqual(S.run('Ab')(parser2), success('A', stream(['A', 'b'], 1), stream(['A', 'b'])))
+    assert.deepStrictEqual(S.run('ab')(parser2), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('bb')(parser2), error(stream(['b', 'b']), ['"a"', '"A"']))
   })
 
   it('run', () => {

--- a/test/string.ts
+++ b/test/string.ts
@@ -27,6 +27,16 @@ describe('string', () => {
       assert.deepStrictEqual(S.run('barfoo')(parser), error(stream(['b', 'a', 'r', 'f', 'o', 'o']), ['"foo"']))
     })
 
+    it('should parse a non-empty string case insensitive', () => {
+      const parser = S.stringC('fOo')
+      assert.deepStrictEqual(S.run('FoO')(parser), success('FoO', stream(['F', 'o', 'O'], 3), stream(['F', 'o', 'O'])))
+      assert.deepStrictEqual(
+        S.run('fOobAr')(parser),
+        success('fOo', stream(['f', 'O', 'o', 'b', 'A', 'r'], 3), stream(['f', 'O', 'o', 'b', 'A', 'r']))
+      )
+      assert.deepStrictEqual(S.run('bArfOo')(parser), error(stream(['b', 'A', 'r', 'f', 'O', 'o']), ['"fOo"/i']))
+    })
+
     it('should handle long strings without exceeding the recursion limit (#41)', () => {
       const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
       const target = intercalate(monoidString, RA.Foldable)(' ', RA.replicate(1000, lorem))
@@ -58,6 +68,19 @@ describe('string', () => {
     assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
     assert.deepStrictEqual(S.run('ba')(parser), success('b', stream(['b', 'a'], 1), stream(['b', 'a'])))
     assert.deepStrictEqual(S.run('ca')(parser), error(stream(['c', 'a']), ['"a"', '"b"']))
+  })
+
+  it('oneOfC', () => {
+    const parser = S.oneOfC(array)(['A', 'b'])
+    assert.deepStrictEqual(S.run('a')(parser), success('a', stream(['a'], 1), stream(['a'])))
+    assert.deepStrictEqual(S.run('A')(parser), success('A', stream(['A'], 1), stream(['A'])))
+    assert.deepStrictEqual(S.run('b')(parser), success('b', stream(['b'], 1), stream(['b'])))
+    assert.deepStrictEqual(S.run('B')(parser), success('B', stream(['B'], 1), stream(['B'])))
+    assert.deepStrictEqual(S.run('ab')(parser), success('a', stream(['a', 'b'], 1), stream(['a', 'b'])))
+    assert.deepStrictEqual(S.run('Ab')(parser), success('A', stream(['A', 'b'], 1), stream(['A', 'b'])))
+    assert.deepStrictEqual(S.run('ba')(parser), success('b', stream(['b', 'a'], 1), stream(['b', 'a'])))
+    assert.deepStrictEqual(S.run('Ba')(parser), success('B', stream(['B', 'a'], 1), stream(['B', 'a'])))
+    assert.deepStrictEqual(S.run('ca')(parser), error(stream(['c', 'a']), ['"A"/i', '"b"/i']))
   })
 
   it('int', () => {


### PR DESCRIPTION
This is a bit of a "big" PR, so I can split it if necessary.

After going through the entire library for educational purposes, I have came about many things I wanted to add/fix/test and I have came up with the following:

- added `charC` - a case insensitive char parser.
- added `stringC` - a case insensitive string parser.
- added `oneOfC` - a case insensitive one of strings parser.
- Added non breaking change support for the `between` parser to be able to provide 2 different `left` and `right` parsers
- Fixed the semigroup to mark as `fatal` if any was `fatal` and not if just the last one
- Obviously added tests to all additions/changes, maintaining 100% coverage
- Added some missing tests here and there
- Enhanced the command example
- Enhanced small bits of code here and there

@gcanti please let me know how do you want to proceed here, I would appreciate any feedback :-)