### PR TITLE
Fix issues with the many and many1 combinators leading to infinite recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.6.15
+
+- **Bug Fix**
+  - re-implement `many` and `many1` in terms of `ChainRec`, closes #45 (@IMax153)
+
 # 0.6.14
 
 - **Bug Fix**

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -380,7 +380,7 @@ thus guaranteed to contain at least one value.
 **Signature**
 
 ```ts
-export declare const many1: <I, A>(p: Parser<I, A>) => Parser<I, NEA.NonEmptyArray<A>>
+export declare const many1: <I, A>(parser: Parser<I, A>) => Parser<I, NEA.NonEmptyArray<A>>
 ```
 
 Added in v0.6.0

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -246,13 +246,16 @@ export const many = <I, A>(p: Parser<I, A>): Parser<I, Array<A>> =>
  * @category combinators
  * @since 0.6.0
  */
-export const many1: <I, A>(p: Parser<I, A>) => Parser<I, NEA.NonEmptyArray<A>> = p =>
+export const many1 = <I, A>(parser: Parser<I, A>): Parser<I, NEA.NonEmptyArray<A>> =>
   pipe(
-    p,
+    parser,
     chain(head =>
-      pipe(
-        many(p),
-        map(tail => NEA.cons(head, tail))
+      chainRec_(NEA.of(head), acc =>
+        pipe(
+          parser,
+          map(a => E.left(NEA.snoc(acc, a))),
+          alt(() => of(E.right(acc)))
+        )
       )
     )
   )


### PR DESCRIPTION
This PR fixes a long-standing issue with the `many` and `many1` combinators which often led to infinite recursion due to their implementation. This re-implements `many1` (and thus `many`) from the `Parser` module in terms of `ChainRec`, which allows for iterative processing of calls to `many`. 

The tradeoff is that if a user creates a parser which cannot fail or succeed (see #49), the program will continue to run without any output (i.e. it will iterate infinitely instead of recursing infinitely). I think this trade-off is beneficial because `many` can now handle parsing much longer inputs without resulting in a `RangeError`.

For the added test, I only created a `10,000` character long string to avoid CI-CD taking too long. I did test with a `100,000` character long string as well, but the tests took ~30 seconds to run. Happy to change this if desired.

Closes #45. 